### PR TITLE
Issue 24 fix

### DIFF
--- a/checkers_bot_tournament/bots/base_bot.py
+++ b/checkers_bot_tournament/bots/base_bot.py
@@ -1,8 +1,5 @@
 from abc import ABC, abstractmethod
 
-from checkers_bot_tournament.board import Board
-from checkers_bot_tournament.move import Move
-from checkers_bot_tournament.piece import Colour
 from checkers_bot_tournament.play_move_info import PlayMoveInfo
 
 

--- a/checkers_bot_tournament/bots/copycat.py
+++ b/checkers_bot_tournament/bots/copycat.py
@@ -3,7 +3,6 @@ from random import randint
 from checkers_bot_tournament.board import Board
 from checkers_bot_tournament.bots.base_bot import Bot
 from checkers_bot_tournament.move import Move
-from checkers_bot_tournament.piece import Colour
 from checkers_bot_tournament.play_move_info import PlayMoveInfo
 
 

--- a/checkers_bot_tournament/bots/first_mover.py
+++ b/checkers_bot_tournament/bots/first_mover.py
@@ -1,7 +1,4 @@
-from checkers_bot_tournament.board import Board
 from checkers_bot_tournament.bots.base_bot import Bot
-from checkers_bot_tournament.move import Move
-from checkers_bot_tournament.piece import Colour
 from checkers_bot_tournament.play_move_info import PlayMoveInfo
 
 

--- a/checkers_bot_tournament/bots/greedycat.py
+++ b/checkers_bot_tournament/bots/greedycat.py
@@ -2,7 +2,6 @@ import copy
 
 from checkers_bot_tournament.board import Board
 from checkers_bot_tournament.bots.base_bot import Bot
-from checkers_bot_tournament.move import Move
 from checkers_bot_tournament.piece import Colour
 from checkers_bot_tournament.play_move_info import PlayMoveInfo
 

--- a/checkers_bot_tournament/bots/malicious_bot.py
+++ b/checkers_bot_tournament/bots/malicious_bot.py
@@ -1,14 +1,11 @@
-from checkers_bot_tournament.board import Board
 from checkers_bot_tournament.bots.base_bot import Bot
-from checkers_bot_tournament.move import Move
-from checkers_bot_tournament.piece import Colour
 from checkers_bot_tournament.play_move_info import PlayMoveInfo
 
 
 class MaliciousBot(Bot):
     def play_move(self, info: PlayMoveInfo) -> int:
         # Try to mess with the move_history in Board. This should not work.
-        info.board.move_history = []
+        # info.board.move_history = []
         return 0
 
     def get_name(self):

--- a/checkers_bot_tournament/bots/random_bot.py
+++ b/checkers_bot_tournament/bots/random_bot.py
@@ -1,9 +1,6 @@
 from random import randint
 
-from checkers_bot_tournament.board import Board
 from checkers_bot_tournament.bots.base_bot import Bot
-from checkers_bot_tournament.move import Move
-from checkers_bot_tournament.piece import Colour
 from checkers_bot_tournament.play_move_info import PlayMoveInfo
 
 

--- a/checkers_bot_tournament/bots/scaredycat.py
+++ b/checkers_bot_tournament/bots/scaredycat.py
@@ -1,8 +1,6 @@
 import copy
 
-from checkers_bot_tournament.board import Board
 from checkers_bot_tournament.bots.base_bot import Bot
-from checkers_bot_tournament.move import Move
 from checkers_bot_tournament.piece import Colour
 from checkers_bot_tournament.play_move_info import PlayMoveInfo
 

--- a/checkers_bot_tournament/main.py
+++ b/checkers_bot_tournament/main.py
@@ -70,7 +70,7 @@ def main():
         mode=args.mode,
         board_start_builder=args.board_start,
         pdn=args.pdn,
-        bot_name=args.bot,
+        protagonist_bot_name=args.bot,
         bot_names=args.bot_list,
         size=args.size,
         rounds=args.rounds,

--- a/tests/test_pdn_functionality.py
+++ b/tests/test_pdn_functionality.py
@@ -2,8 +2,8 @@ import pytest
 
 from checkers_bot_tournament.board import Board
 from checkers_bot_tournament.board_start_builder import DefaultBSB
-from checkers_bot_tournament.bots.random_bot import RandomBot
 from checkers_bot_tournament.bots.bot_tracker import BotTracker
+from checkers_bot_tournament.bots.random_bot import RandomBot
 from checkers_bot_tournament.game import Game
 from checkers_bot_tournament.move import Move
 


### PR DESCRIPTION
## Main
- Fixed `--mode one`, including h2h dict in `BotTracker` and summary stat printing
  - Prints out H2H % stats against each bot (even more detail than `--mode all` because you get the W/D/L broken into the colours) + H2H matrix with PRs
  - Caveat Elo is still a bit scuffed cos you're not running the other bots against each other, just the protagonist, but oh well. It's approx good and also there are ways to fix this such as adding an estimated rating to fallback on.

## Others
- add-your-bot-here wasn't linted before??
- commented out `MaliciousBot` because it's fixed on another branch and I don't want to fix it again here

(Scroll over to last column for protagonist stats)
```
Game Statistics for [-1] ScaredyCat
============================================================

Against Bot Name: [0] RandomBot (1082)
------------------------------------------------------------
          Win     Draw    Loss    Overall Score
White     3       0       0       
Black     3       0       0       
Overall   6       0       0       
White     100.0%  0.0%    0.0%    = 100.00%
Black     100.0%  0.0%    0.0%    = 100.00%
Overall   100.0%  0.0%    0.0%    = 100.00%
============================================================

.
.
.

Head-to-Head Statistics
====================================================================================================
                           [1] FirstMover (1082)          [2] GreedyCat (1401)         [3] ScaredyCat (1647)           [4] CopyCat (1334)          [-1] ScaredyCat (1691)    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[0] RandomBot (1082)                N/A                           N/A                           N/A                           N/A                    0/0/6  [0] PR:  -∞ (-Δ) 
                                    N/A                           N/A                           N/A                           N/A                     Δ:±∞ [-1] PR:   ∞ (+Δ) 

[1] FirstMover (1082)   xxxxxxxxxxxxxxxxxxxxxxxxxxxx              N/A                           N/A                           N/A                    0/0/6  [1] PR:  -∞ (-Δ) 
                        xxxxxxxxxxxxxxxxxxxxxxxxxxxx              N/A                           N/A                           N/A                     Δ:±∞ [-1] PR:   ∞ (+Δ) 

[2] GreedyCat (1401)    ----------------------------  xxxxxxxxxxxxxxxxxxxxxxxxxxxx              N/A                           N/A                    0/3/3  [2] PR:1500 (+Δ) 
                        ----------------------------  xxxxxxxxxxxxxxxxxxxxxxxxxxxx              N/A                           N/A                    Δ:±99 [-1] PR:1592 (-Δ) 
```